### PR TITLE
Add php5-imagick extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Kevin Delfour <kevin@delfour.eu>
 RUN apt-get update
 RUN apt-get install -yq wget git unzip nginx fontconfig-config fonts-dejavu-core \
     php5-fpm php5-common php5-json php5-cli php5-common php5-mysql\
-    php5-gd php5-json php5-mcrypt php5-readline psmisc ssl-cert \
+    php5-gd php5-imagick php5-json php5-mcrypt php5-readline psmisc ssl-cert \
     ufw php-pear libgd-tools libmcrypt-dev mcrypt mysql-server mysql-client
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
From the [Lychee README](https://github.com/electerious/Lychee/blob/master/README.md#imagick):

> Lychee uses Imagick when installed on your server. In this case you will benefit from a faster processing of your uploads, better looking thumbnails and intermediate sized images for small screen devices. You can disable the usage of Imagick in the settings.